### PR TITLE
Remove provider config from Alibaba Cloud modules

### DIFF
--- a/modules/ali-cluster/main.tf
+++ b/modules/ali-cluster/main.tf
@@ -1,19 +1,7 @@
-terraform {
-  # The configuration for this backend will be filled in by Terragrunt
-  backend "gcs" {}
-}
-
-provider "alicloud" {
-  version    = ">= 1.9.1"
-  region     = "eu-central-1"
-  access_key = "${chomp(file("${var.access_key}"))}"
-  secret_key = "${chomp(file("${var.secret_key}"))}"
-}
-
 resource "alicloud_cs_kubernetes" "k8s_cluster" {
   name_prefix = "k8s-cluster"
 
-  new_nat_gateway = true
+  new_nat_gateway = "${var.new_nat_gateway}"
   vswitch_id      = "${var.vswitch_id}"
   is_outdated     = false
 

--- a/modules/ali-cluster/variables.tf
+++ b/modules/ali-cluster/variables.tf
@@ -1,5 +1,6 @@
-variable "access_key" {}
-variable "secret_key" {}
-
 variable "ssh_password" {}
 variable "vswitch_id" {}
+
+variable "new_nat_gateway" {
+  default = false
+}

--- a/modules/ali-network/main.tf
+++ b/modules/ali-network/main.tf
@@ -1,20 +1,4 @@
 # ------------------------------------------------------------------------------
-# TERRAFORM / PROVIDER CONFIG
-# ------------------------------------------------------------------------------
-
-terraform {
-  # The configuration for this backend will be filled in by Terragrunt
-  backend "gcs" {}
-}
-
-provider "alicloud" {
-  version    = ">= 1.9.1"
-  region     = "eu-central-1"
-  access_key = "${chomp(file("${var.access_key}"))}"
-  secret_key = "${chomp(file("${var.secret_key}"))}"
-}
-
-# ------------------------------------------------------------------------------
 # VPC NETWORK, VSWITCHES, SECURITY GROUPS
 # ------------------------------------------------------------------------------
 

--- a/modules/ali-network/variables.tf
+++ b/modules/ali-network/variables.tf
@@ -1,11 +1,3 @@
-variable "access_key" {
-  description = "Path to file with Alibaba Cloud Access Key ID"
-}
-
-variable "secret_key" {
-  description = "Path to file with Alibaba Cloud Access Key Secret"
-}
-
 variable "vpc_cidr" {
   description = "The cidr block used to launch a new VPC"
   default     = "10.0.0.0/8"


### PR DESCRIPTION
In this pull request:

- [x] Remove provider config from modules ali-network and ali-cluster
- [x] Remove empty Terraform backend config
- [x] Do not create a NAT gateway by default (not in Alibaba Cloud's free trial) in ali-cluster module
