### PR TITLE
Remove google_project_service.services from gke-network module

### DIFF
--- a/modules/gke-network/README.md
+++ b/modules/gke-network/README.md
@@ -43,7 +43,6 @@ All module input variables and variable descriptions can be found in [variables.
 
 By default:
 
-- [`google_project_service`](https://www.terraform.io/docs/providers/google/r/google_project_service.html).`services`
 - [`google_compute_network`](https://www.terraform.io/docs/providers/google/r/compute_network.html).`network`
 - [`google_compute_subnetwork`](https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html).`subnets`
 - [`google_compute_firewall`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html).`allow_nodes_internal`

--- a/modules/gke-network/main.tf
+++ b/modules/gke-network/main.tf
@@ -1,26 +1,8 @@
 # ------------------------------------------------------------------------------
-# GOOGLE CLOUD PROJECT
-# ------------------------------------------------------------------------------
-
-resource "google_project_service" "services" {
-  count = "${length(var.project_services)}"
-
-  disable_on_destroy = false
-
-  service = "${element(var.project_services, count.index)}"
-
-  provisioner "local-exec" {
-    command = "sleep 60"
-  }
-}
-
-# ------------------------------------------------------------------------------
 # VPC NETWORK, SUBNETS, FIREWALL RULES
 # ------------------------------------------------------------------------------
 
 resource "google_compute_network" "network" {
-  depends_on = ["google_project_service.services"]
-
   name                    = "network"
   auto_create_subnetworks = false
 }
@@ -102,8 +84,6 @@ resource "google_compute_firewall" "allow_pods_internal" {
 }
 
 resource "null_resource" "delete_default_network" {
-  depends_on = ["google_project_service.services"]
-
   provisioner "local-exec" {
     command = <<EOF
 gcloud --project $TF_VAR_project_id --quiet compute firewall-rules delete \
@@ -123,8 +103,7 @@ EOF
 # ------------------------------------------------------------------------------
 
 resource "google_compute_address" "ingress_controller_ip" {
-  count      = "${var.create_static_ip_address ? 1 : 0}"
-  depends_on = ["google_project_service.services"]
+  count = "${var.create_static_ip_address ? 1 : 0}"
 
   name         = "ingress-controller-ip"
   region       = "${var.static_ip_region}"
@@ -136,8 +115,7 @@ resource "google_compute_address" "ingress_controller_ip" {
 # ------------------------------------------------------------------------------
 
 resource "google_dns_managed_zone" "dns_zones" {
-  count      = "${length(var.dns_zones) > 0 ? length(var.dns_zones) : 0}"
-  depends_on = ["google_project_service.services"]
+  count = "${length(var.dns_zones) > 0 ? length(var.dns_zones) : 0}"
 
   name     = "${element(keys(var.dns_zones), count.index)}"
   dns_name = "${element(values(var.dns_zones), count.index)}"

--- a/modules/gke-network/variables.tf
+++ b/modules/gke-network/variables.tf
@@ -2,21 +2,6 @@
 # OPTIONAL VARIABLES
 # ------------------------------------------------------------------------------
 
-variable "project_services" {
-  type        = "list"
-  description = "Google Cloud APIs to enable for the GCP project"
-
-  default = [
-    "compute.googleapis.com",
-    "container.googleapis.com",
-    "containerregistry.googleapis.com",
-    "cloudkms.googleapis.com",
-    "dns.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "iam.googleapis.com",
-  ]
-}
-
 variable "cluster_subnets" {
   type        = "map"
   description = "A map of index to a comma separated list of `region,nodes-subnet,pods-subnet,services-subnet` string."


### PR DESCRIPTION
Discussion in https://github.com/exekube/exekube/pull/91#issuecomment-395228152

Removes Google API management functionality completely from the `gke-network` module