### PR TITLE
Add AWS/EKS modules

### DIFF
--- a/modules/eks-cluster/NOTICE
+++ b/modules/eks-cluster/NOTICE
@@ -1,0 +1,2 @@
+Copyright (c) 2018 Terraform AWS provider Contributors
+Copied from https://github.com/terraform-providers/terraform-provider-aws

--- a/modules/eks-cluster/eks-cluster.tf
+++ b/modules/eks-cluster/eks-cluster.tf
@@ -1,0 +1,87 @@
+#
+# EKS Cluster Resources
+#  * IAM Role to allow EKS service to manage other AWS services
+#  * EC2 Security Group to allow networking traffic with EKS cluster
+#  * EKS Cluster
+#
+
+resource "aws_iam_role" "demo-cluster" {
+  name = "terraform-eks-demo-cluster"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = "${aws_iam_role.demo-cluster.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "demo-cluster-AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = "${aws_iam_role.demo-cluster.name}"
+}
+
+resource "aws_security_group" "demo-cluster" {
+  name        = "terraform-eks-demo-cluster"
+  description = "Cluster communication with worker nodes"
+  vpc_id      = "${aws_vpc.demo.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "terraform-eks-demo"
+  }
+}
+
+resource "aws_security_group_rule" "demo-cluster-ingress-node-https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.demo-cluster.id}"
+  source_security_group_id = "${aws_security_group.demo-node.id}"
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "demo-cluster-ingress-workstation-https" {
+  cidr_blocks       = ["${local.workstation-external-cidr}"]
+  description       = "Allow workstation to communicate with the cluster API Server"
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.demo-cluster.id}"
+  to_port           = 443
+  type              = "ingress"
+}
+
+resource "aws_eks_cluster" "demo" {
+  name     = "${var.cluster-name}"
+  role_arn = "${aws_iam_role.demo-cluster.arn}"
+
+  vpc_config {
+    security_group_ids = ["${aws_security_group.demo-cluster.id}"]
+    subnet_ids         = ["${aws_subnet.demo.*.id}"]
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.demo-cluster-AmazonEKSClusterPolicy",
+    "aws_iam_role_policy_attachment.demo-cluster-AmazonEKSServicePolicy",
+  ]
+}

--- a/modules/eks-cluster/eks-worker-nodes.tf
+++ b/modules/eks-cluster/eks-worker-nodes.tf
@@ -1,0 +1,149 @@
+#
+# EKS Worker Nodes Resources
+#  * IAM role allowing Kubernetes actions to access other AWS services
+#  * EC2 Security Group to allow networking traffic
+#  * Data source to fetch latest EKS worker AMI
+#  * AutoScaling Launch Configuration to configure worker instances
+#  * AutoScaling Group to launch worker instances
+#
+
+resource "aws_iam_role" "demo-node" {
+  name = "terraform-eks-demo-node"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "demo-node-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = "${aws_iam_role.demo-node.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "demo-node-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = "${aws_iam_role.demo-node.name}"
+}
+
+resource "aws_iam_instance_profile" "demo-node" {
+  name = "terraform-eks-demo"
+  role = "${aws_iam_role.demo-node.name}"
+}
+
+resource "aws_security_group" "demo-node" {
+  name        = "terraform-eks-demo-node"
+  description = "Security group for all nodes in the cluster"
+  vpc_id      = "${aws_vpc.demo.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = "${
+    map(
+     "Name", "terraform-eks-demo-node",
+     "kubernetes.io/cluster/${var.cluster-name}", "owned",
+    )
+  }"
+}
+
+resource "aws_security_group_rule" "demo-node-ingress-self" {
+  description              = "Allow node to communicate with each other"
+  from_port                = 0
+  protocol                 = "-1"
+  security_group_id        = "${aws_security_group.demo-node.id}"
+  source_security_group_id = "${aws_security_group.demo-node.id}"
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "demo-node-ingress-cluster" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.demo-node.id}"
+  source_security_group_id = "${aws_security_group.demo-cluster.id}"
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+data "aws_ami" "eks-worker" {
+  filter {
+    name   = "name"
+    values = ["eks-worker-*"]
+  }
+
+  most_recent = true
+  owners      = ["602401143452"] # Amazon
+}
+
+locals {
+  demo-node-userdata = <<USERDATA
+#!/bin/bash -xe
+
+CA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki
+CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
+mkdir -p $CA_CERTIFICATE_DIRECTORY
+echo "${aws_eks_cluster.demo.certificate_authority.0.data}" | base64 -d >  $CA_CERTIFICATE_FILE_PATH
+INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.master_endpoint},g /var/lib/kubelet/kubeconfig
+sed -i s,CLUSTER_NAME,${var.cluster-name},g /var/lib/kubelet/kubeconfig
+sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.master_endpoint},g /etc/systemd/system/kubelet.service
+sed -i s,MASTER_ENDPOINT,${aws_eks_cluster.demo.master_endpoint},g /etc/systemd/system/kube-proxy.service
+sed -i s,INTERNAL_IP,$INTERNAL_IP,g /etc/systemd/system/kubelet.service
+sed -i s,INTERNAL_IP,$INTERNAL_IP,g /etc/systemd/system/kube-proxy.service
+sed -i s,CERTIFICATE_AUTHORITY_FILE,$CA_CERTIFICATE_FILE_PATH,g /var/lib/kubelet/kubeconfig
+sed -i s,CLIENT_CA_FILE,$CA_CERTIFICATE_FILE_PATH,g  /etc/systemd/system/kubelet.service
+systemctl daemon-reload
+systemctl restart kubelet kube-proxy
+USERDATA
+}
+
+resource "aws_launch_configuration" "demo" {
+  associate_public_ip_address = true
+  iam_instance_profile        = "${aws_iam_instance_profile.demo-node.name}"
+  image_id                    = "${data.aws_ami.eks-worker.id}"
+  instance_type               = "m4.large"
+  name_prefix                 = "terraform-eks-demo"
+  security_groups             = ["${aws_security_group.demo-node.id}"]
+  user_data_base64            = "${base64encode(local.demo-node-userdata)}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "demo" {
+  desired_capacity     = 2
+  launch_configuration = "${aws_launch_configuration.demo.id}"
+  max_size             = 2
+  min_size             = 1
+  name                 = "terraform-eks-demo"
+  vpc_zone_identifier  = ["${aws_subnet.demo.*.id}"]
+
+  tag {
+    key                 = "Name"
+    value               = "terraform-eks-demo"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "kubernetes.io/cluster/${var.cluster-name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+}

--- a/modules/eks-cluster/outputs.tf
+++ b/modules/eks-cluster/outputs.tf
@@ -1,0 +1,56 @@
+#
+# Outputs
+#
+
+locals {
+  config-map-aws-auth = <<CONFIGMAPAWSAUTH
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: default
+data:
+  mapRoles: |
+    - rolearn: ${aws_iam_role.demo-node.arn}
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes
+        - system:node-proxier
+CONFIGMAPAWSAUTH
+
+  kubeconfig = <<KUBECONFIG
+apiVersion: v1
+clusters:
+- cluster:
+    server: ${aws_eks_cluster.demo.endpoint}
+    certificate-authority-data: ${aws_eks_cluster.demo.certificate_authority.0.data}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: aws
+  name: aws
+current-context: aws
+kind: Config
+preferences: {}
+users:
+- name: aws
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: heptio-authenticator-aws
+      args:
+        - "token"
+        - "-i"
+        - "${var.cluster-name}"
+KUBECONFIG
+}
+
+output "config-map-aws-auth" {
+  value = "${local.config-map-aws-auth}"
+}
+
+output "kubeconfig" {
+  value = "${local.kubeconfig}"
+}

--- a/modules/eks-cluster/providers.tf
+++ b/modules/eks-cluster/providers.tf
@@ -1,0 +1,17 @@
+#
+# Provider Configuration
+#
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+# Using this data source allows the configuration to be
+# generic for any region.
+data "aws_availability_zones" "available" {}
+
+# Not required: currently used in conjuction with using
+# icanhazip.com to determine local workstation external IP
+# to open EC2 Security Group access to the Kubernetes cluster.
+# See workstation-external-ip.tf for additional information.
+provider "http" {}

--- a/modules/eks-cluster/variables.tf
+++ b/modules/eks-cluster/variables.tf
@@ -1,0 +1,8 @@
+#
+# Variables Configuration
+#
+
+variable "cluster-name" {
+  default = "terraform-eks-demo"
+  type    = "string"
+}

--- a/modules/eks-network/NOTICE
+++ b/modules/eks-network/NOTICE
@@ -1,0 +1,2 @@
+Copyright (c) 2018 Terraform AWS provider Contributors
+Copied from https://github.com/terraform-providers/terraform-provider-aws

--- a/modules/eks-network/providers.tf
+++ b/modules/eks-network/providers.tf
@@ -1,0 +1,17 @@
+#
+# Provider Configuration
+#
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+# Using this data source allows the configuration to be
+# generic for any region.
+data "aws_availability_zones" "available" {}
+
+# Not required: currently used in conjuction with using
+# icanhazip.com to determine local workstation external IP
+# to open EC2 Security Group access to the Kubernetes cluster.
+# See workstation-external-ip.tf for additional information.
+provider "http" {}

--- a/modules/eks-network/vpc.tf
+++ b/modules/eks-network/vpc.tf
@@ -1,0 +1,57 @@
+#
+# VPC Resources
+#  * VPC
+#  * Subnets
+#  * Internet Gateway
+#  * Route Table
+#
+
+resource "aws_vpc" "demo" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = "${
+    map(
+     "Name", "terraform-eks-demo-node",
+     "kubernetes.io/cluster/${var.cluster-name}", "shared",
+    )
+  }"
+}
+
+resource "aws_subnet" "demo" {
+  count = 2
+
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  cidr_block        = "10.0.${count.index}.0/24"
+  vpc_id            = "${aws_vpc.demo.id}"
+
+  tags = "${
+    map(
+     "Name", "terraform-eks-demo-node",
+     "kubernetes.io/cluster/${var.cluster-name}", "shared",
+    )
+  }"
+}
+
+resource "aws_internet_gateway" "demo" {
+  vpc_id = "${aws_vpc.demo.id}"
+
+  tags {
+    Name = "terraform-eks-demo"
+  }
+}
+
+resource "aws_route_table" "demo" {
+  vpc_id = "${aws_vpc.demo.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.demo.id}"
+  }
+}
+
+resource "aws_route_table_association" "demo" {
+  count = 2
+
+  subnet_id      = "${aws_subnet.demo.*.id[count.index]}"
+  route_table_id = "${aws_route_table.demo.id}"
+}

--- a/modules/gke-network/README.md
+++ b/modules/gke-network/README.md
@@ -43,7 +43,6 @@ All module input variables and variable descriptions can be found in [variables.
 
 By default:
 
-- [`google_project_service`](https://www.terraform.io/docs/providers/google/r/google_project_service.html).`services`
 - [`google_compute_network`](https://www.terraform.io/docs/providers/google/r/compute_network.html).`network`
 - [`google_compute_subnetwork`](https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html).`subnets`
 - [`google_compute_firewall`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html).`allow_nodes_internal`

--- a/modules/gke-network/main.tf
+++ b/modules/gke-network/main.tf
@@ -1,26 +1,8 @@
 # ------------------------------------------------------------------------------
-# GOOGLE CLOUD PROJECT
-# ------------------------------------------------------------------------------
-
-resource "google_project_service" "services" {
-  count = "${length(var.project_services)}"
-
-  disable_on_destroy = false
-
-  service = "${element(var.project_services, count.index)}"
-
-  provisioner "local-exec" {
-    command = "sleep 60"
-  }
-}
-
-# ------------------------------------------------------------------------------
 # VPC NETWORK, SUBNETS, FIREWALL RULES
 # ------------------------------------------------------------------------------
 
 resource "google_compute_network" "network" {
-  depends_on = ["google_project_service.services"]
-
   name                    = "network"
   auto_create_subnetworks = false
 }
@@ -102,8 +84,6 @@ resource "google_compute_firewall" "allow_pods_internal" {
 }
 
 resource "null_resource" "delete_default_network" {
-  depends_on = ["google_project_service.services"]
-
   provisioner "local-exec" {
     command = <<EOF
 gcloud --project $TF_VAR_project_id --quiet compute firewall-rules delete \
@@ -123,8 +103,7 @@ EOF
 # ------------------------------------------------------------------------------
 
 resource "google_compute_address" "ingress_controller_ip" {
-  count      = "${var.create_static_ip_address ? 1 : 0}"
-  depends_on = ["google_project_service.services"]
+  count = "${var.create_static_ip_address ? 1 : 0}"
 
   name         = "ingress-controller-ip"
   region       = "${var.static_ip_region}"
@@ -136,8 +115,7 @@ resource "google_compute_address" "ingress_controller_ip" {
 # ------------------------------------------------------------------------------
 
 resource "google_dns_managed_zone" "dns_zones" {
-  count      = "${length(var.dns_zones) > 0 ? length(var.dns_zones) : 0}"
-  depends_on = ["google_project_service.services"]
+  count = "${length(var.dns_zones) > 0 ? length(var.dns_zones) : 0}"
 
   name     = "${element(keys(var.dns_zones), count.index)}"
   dns_name = "${element(values(var.dns_zones), count.index)}"

--- a/modules/gke-network/variables.tf
+++ b/modules/gke-network/variables.tf
@@ -2,21 +2,6 @@
 # OPTIONAL VARIABLES
 # ------------------------------------------------------------------------------
 
-variable "project_services" {
-  type        = "list"
-  description = "Google Cloud APIs to enable for the GCP project"
-
-  default = [
-    "compute.googleapis.com",
-    "container.googleapis.com",
-    "containerregistry.googleapis.com",
-    "cloudkms.googleapis.com",
-    "dns.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "iam.googleapis.com",
-  ]
-}
-
 variable "cluster_subnets" {
   type        = "map"
   description = "A map of index to a comma separated list of `region,nodes-subnet,pods-subnet,services-subnet` string."


### PR DESCRIPTION
These modules will use AWS/EKS as a full equivalent of the currently functional GCP/GKE modules (`gke-network`, `gke-cluster`)

- [x] Add `eks-network` module
- [ ] Ensure `eks-network` is functional
- [x] Add `eks-cluster` module
- [ ] Ensure `eks-cluster` is functional