### PR TITLE
Uncomment static_ip_address output in gke-network module

### DIFF
--- a/modules/gke-network/outputs.tf
+++ b/modules/gke-network/outputs.tf
@@ -1,8 +1,6 @@
-/*
 output "static_ip_address" {
   value = "${google_compute_address.ingress_controller_ip.0.address}"
 }
-*/
 
 output "dns_zones" {
   value = ["${google_dns_managed_zone.dns_zones.*.dns_name}"]


### PR DESCRIPTION
@ilyasotkov It is unclear why `static_ip_address` output is commented, but we are using it to assign static IP for our `nginx-ingress` controller.