### PR TITLE
Add missing configuration blocks into gcp-api-mgmt module

### DIFF
--- a/modules/gcp-api-mgmt/main.tf
+++ b/modules/gcp-api-mgmt/main.tf
@@ -1,3 +1,17 @@
+# ------------------------------------------------------------------------------
+# TERRAFORM / PROVIDER CONFIG
+# ------------------------------------------------------------------------------
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "gcs" {}
+}
+
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
 # GCP sevices aka APIs to enable for the GCP project
 resource "google_project_service" "services" {
   count = "${length(var.project_services)}"

--- a/modules/gcp-api-mgmt/variables.tf
+++ b/modules/gcp-api-mgmt/variables.tf
@@ -1,4 +1,16 @@
 # ------------------------------------------------------------------------------
+# REQUIRED VARIABLES
+# ------------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "Project where resources will be created"
+}
+
+variable "serviceaccount_key" {
+  description = "Service account key for the project"
+}
+
+# ------------------------------------------------------------------------------
 # OPTIONAL VARIABLES
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
@ilyasotkov I am not sure why these blocks are missing, but without them it is impossible to use `gcp-api-mgmt` module the same way that we use other modules.