### PR TITLE
Make timeouts configurable for gke-cluster

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -97,4 +97,10 @@ creator-cluster-admin-binding \
 && helm init --client-only
 EOF
   }
+
+  timeouts {
+    create = "${var.create_timeout}"
+    update = "${var.update_timeout}"
+    delete = "${var.delete_timeout}"
+  }
 }

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -68,3 +68,15 @@ variable "monitoring_service" {
 variable "logging_service" {
   default = "logging.googleapis.com"
 }
+
+variable "create_timeout" {
+  default = "30m"
+}
+
+variable "update_timeout" {
+  default = "10m"
+}
+
+variable "delete_timeout" {
+  default = "10m"
+}


### PR DESCRIPTION
We found that some times 10 minutes (default update timeout) is not enough to complete cluster upgrade while migrating to different k8s version.

By default all timeouts are [defaults for google container cluster](https://www.terraform.io/docs/providers/google/r/container_cluster.html#timeouts).