### PR TITLE
Gcp stackdriver exclusion

### DIFF
--- a/modules/gcp-stackdriver-exclusion/main.tf
+++ b/modules/gcp-stackdriver-exclusion/main.tf
@@ -17,8 +17,9 @@ provider "google" {
 # ------------------------------------------------------------------------------
 
 resource "google_logging_project_exclusion" "my-exclusion" {
-  count  = "${length(var.exclusions)}"
-  name   = "${element(keys(var.exclusions), count.index)}"
+  count = "${length(var.exclusions)}"
+  name  = "${element(keys(var.exclusions), count.index)}"
+
   # logName is a common thing to filter on. Per
   # https://cloud.google.com/logging/docs/view/advanced-filters#minimize_global_and_substring_searches,
   # it is best to match on an exact string. Doing so requires knowing

--- a/modules/gcp-stackdriver-exclusion/main.tf
+++ b/modules/gcp-stackdriver-exclusion/main.tf
@@ -17,7 +17,7 @@ provider "google" {
 # ------------------------------------------------------------------------------
 
 resource "google_logging_project_exclusion" "my-exclusion" {
-  name        = "${var.exclusion_name}"
-  description = "${var.exclusion_description}"
-  filter      = "${var.exclusion_filter}"
+  count  = "${length(var.exclusions)}"
+  name   = "${element(keys(var.exclusions), count.index)}"
+  filter = "${element(values(var.exclusions), count.index)}"
 }

--- a/modules/gcp-stackdriver-exclusion/main.tf
+++ b/modules/gcp-stackdriver-exclusion/main.tf
@@ -19,5 +19,18 @@ provider "google" {
 resource "google_logging_project_exclusion" "my-exclusion" {
   count  = "${length(var.exclusions)}"
   name   = "${element(keys(var.exclusions), count.index)}"
-  filter = "${element(values(var.exclusions), count.index)}"
+  # logName is a common thing to filter on. Per
+  # https://cloud.google.com/logging/docs/view/advanced-filters#minimize_global_and_substring_searches,
+  # it is best to match on an exact string. Doing so requires knowing
+  # var.project_id (since logName starts with "projects/my-project-id/").
+  # Neither Terraform variables (var.project_id) nor their environment variable
+  # cousins (TF_VAR_project_id) are availble from terraform.tfvars, where an
+  # instance of this module declares its filters. Hence, this workaround to
+  # replace the string "__var.project_id__" with the value of ${var.project_id}
+  # at runtime.
+  filter = "${replace(
+              element(values(var.exclusions), count.index),
+              "__var.project_id__",
+              "${var.project_id}"
+            )}"
 }

--- a/modules/gcp-stackdriver-exclusion/main.tf
+++ b/modules/gcp-stackdriver-exclusion/main.tf
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------------------
+# TERRAFORM / PROVIDER CONFIG
+# ------------------------------------------------------------------------------
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "gcs" {}
+}
+
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
+# ------------------------------------------------------------------------------
+# GOOGLE STACKDRIVER EXCLUSION
+# ------------------------------------------------------------------------------
+
+resource "google_logging_project_exclusion" "my-exclusion" {
+  name        = "${var.exclusion_name}"
+  description = "${var.exclusion_description}"
+  filter      = "${var.exclusion_filter}"
+}

--- a/modules/gcp-stackdriver-exclusion/variables.tf
+++ b/modules/gcp-stackdriver-exclusion/variables.tf
@@ -15,7 +15,7 @@ variable "serviceaccount_key" {
 # ------------------------------------------------------------------------------
 
 variable "exclusions" {
-  type = "map"
+  type        = "map"
   description = "Map of Stackdriver exclusion rules where keys are names of rules and values are filters implementing those rules"
 
   # Example: {"exclude-all-foo" = "logName=\"projects/__var.project_id__/logs/foo\"}

--- a/modules/gcp-stackdriver-exclusion/variables.tf
+++ b/modules/gcp-stackdriver-exclusion/variables.tf
@@ -10,14 +10,14 @@ variable "serviceaccount_key" {
   description = "Service account key for the project"
 }
 
-variable "exclusion_name" {
-  description = "Name of Stackdriver exclusion rule"
-}
+# ------------------------------------------------------------------------------
+# OPTIONAL VARIABLES
+# ------------------------------------------------------------------------------
 
-variable "exclusion_description" {
-  description = "Description of Stackdriver exclusion rule"
-}
+variable "exclusions" {
+  type = "map"
+  description = "Map of Stackdriver exclusion rules where keys are names of rules and values are filters implementing those rules"
 
-variable "exclusion_filter" {
-  description = "Stackdriver filter defining what will be excluded"
+  # Example: {"drop-all-foos" = "textPayload:\"foo\"}
+  default = {}
 }

--- a/modules/gcp-stackdriver-exclusion/variables.tf
+++ b/modules/gcp-stackdriver-exclusion/variables.tf
@@ -18,6 +18,6 @@ variable "exclusions" {
   type = "map"
   description = "Map of Stackdriver exclusion rules where keys are names of rules and values are filters implementing those rules"
 
-  # Example: {"drop-all-foos" = "textPayload:\"foo\"}
+  # Example: {"exclude-all-foo" = "logName=\"projects/__var.project_id__/logs/foo\"}
   default = {}
 }

--- a/modules/gcp-stackdriver-exclusion/variables.tf
+++ b/modules/gcp-stackdriver-exclusion/variables.tf
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------------------
+# REQUIRED VARIABLES
+# ------------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "Project where resources will be created"
+}
+
+variable "serviceaccount_key" {
+  description = "Service account key for the project"
+}
+
+variable "exclusion_name" {
+  description = "Name of Stackdriver exclusion rule"
+}
+
+variable "exclusion_description" {
+  description = "Description of Stackdriver exclusion rule"
+}
+
+variable "exclusion_filter" {
+  description = "Stackdriver filter defining what will be excluded"
+}


### PR DESCRIPTION
See https://issues.gpii.net/browse/GPII-3327 for the motivation for this module.

See https://github.com/gpii-ops/gpii-infra/blob/master/gcp/modules/gcp-stackdriver-exclusion/main.tf for an example of how we use this module in gpii-infra.

We had a lot of discussion about how to handle injection `project_id` into filters for exact matching: https://github.com/gpii-ops/exekube/pull/12#issuecomment-425732814. (There is also discussion in this PR, though it's a little more chaotic: https://github.com/gpii-ops/gpii-infra/pull/114)