### PR TITLE
Install the Terraform plugins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !dockerfiles/
 !cli/
 !modules/
+!terraform-plugins/

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -89,6 +89,15 @@ RUN curl -L -o ./tph.tar.gz \
         && mkdir -p /root/.terraform.d/plugins/ \
         && mv terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} /root/.terraform.d/plugins/
 
+COPY terraform-plugins /terraform-plugins/
+
+RUN cd /terraform-plugins \
+    && terraform init \
+    && find /terraform-plugins \
+    && cp /terraform-plugins/.terraform/plugins/linux_amd64/terraform-provider* /root/.terraform.d/plugins/ \
+    && cd \
+    && rm -fr /terraform-plugins
+
 COPY modules /exekube-modules/
 COPY --from=builder /build/bin/xk /usr/local/bin/
 ENV PATH /exekube-modules/gcp-project-init:/exekube-modules/gcp-secret-mgmt/scripts:$PATH

--- a/terraform-plugins/providers.tf
+++ b/terraform-plugins/providers.tf
@@ -1,0 +1,37 @@
+# This is the list of Terraform plugins to be installed in the exekube container
+
+provider "google" {
+  version = "~> 1.16"
+}
+
+provider "random" {
+  version = "~> 1.3"
+}
+
+provider "null" {
+  version = "~> 1.0"
+}
+
+provider "kubernetes" {
+  version = "~> 1.1"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+provider "tls" {
+  version = "~> 1.2"
+}
+
+provider "local" {
+  version = "~> 1.1"
+}
+
+provider "external" {
+  version = "~> 1.0"
+}
+
+provider "aws" {
+  version = "~> 1.36"
+}


### PR DESCRIPTION
This PR has the code needed to save the used Terraform plugins in order to avoid the downloading of all of them every time that Terragrunt changes the working path.