### PR TITLE
Fix tiller redeployment after cluster is recreated

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -76,9 +76,6 @@ resource "google_container_cluster" "cluster" {
     provider = "CALICO"
   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
 
   provisioner "local-exec" {
     command = <<EOF

--- a/modules/helm-initializer/main.tf
+++ b/modules/helm-initializer/main.tf
@@ -26,6 +26,20 @@ data "template_file" "tiller_rbac" {
   }
 }
 
+# tiller_status is introduced as a way to to make sure helm is reinstalled if
+# the cluster is recreated and/or tiller is broken or not present
+#
+# This introduces undesired behavior that tiller will be deployed twice,
+# as the trigger mechanism is not based on the state, but rather on the change
+# of the state. So:
+# - 1st run: resource does not exist, the trigger is evaluated to "" (empty)
+#   -> resource is created
+# - 2nd run: resource does exist, but the trigger changed to "1" -> resource
+#   is recreated
+# - 3rd and subsequent runs: resource does exist, trigger stays "1" -> no
+#   changes unless the tiller is deleted or stops working, if that happens
+#   the trigger changes and cycle described above will repeat once more
+
 data "external" "tiller_status" {
   program = [
     "bash",

--- a/modules/helm-initializer/main.tf
+++ b/modules/helm-initializer/main.tf
@@ -66,7 +66,7 @@ helm reset --force \
 --tls-ca-cert=${local_file.ca_cert.filename} \
 --tls-cert=${local_file.helm_cert.filename} \
 --tls-key=${local_file.helm_key.filename} \
---tiller-connection-timeout 30
+--tiller-connection-timeout ${var.tiller_connection_timeout}
 EOF
   }
 }

--- a/modules/helm-initializer/main.tf
+++ b/modules/helm-initializer/main.tf
@@ -65,7 +65,8 @@ helm reset --force \
 --tls --tls-verify \
 --tls-ca-cert=${local_file.ca_cert.filename} \
 --tls-cert=${local_file.helm_cert.filename} \
---tls-key=${local_file.helm_key.filename}
+--tls-key=${local_file.helm_key.filename} \
+--tiller-connection-timeout 30
 EOF
   }
 }

--- a/modules/helm-initializer/main.tf
+++ b/modules/helm-initializer/main.tf
@@ -32,7 +32,7 @@ data "template_file" "tiller_rbac" {
 # This introduces undesired behavior that tiller will be deployed twice,
 # as the trigger mechanism is not based on the state, but rather on the change
 # of the state. So:
-# - 1st run: resource does not exist, the trigger is evaluated to "" (empty)
+# - 1st run: resource does not exist, the trigger is evaluated to random number
 #   -> resource is created
 # - 2nd run: resource does exist, but the trigger changed to "1" -> resource
 #   is recreated
@@ -44,7 +44,8 @@ data "external" "tiller_status" {
   program = [
     "bash",
     "-c",
-    "REPLICAS=$$(kubectl get deploy tiller-deploy -n ${var.tiller_namespace} -o jsonpath='{.status.readyReplicas}'); jq -n --arg replicas \"$$REPLICAS\" '{readyReplicas:$$replicas}'"]
+    "REPLICAS=$$(kubectl get deploy tiller-deploy -n ${var.tiller_namespace} -o jsonpath='{.status.readyReplicas}'); [ \"$$REPLICAS\" != \"1\" ] && REPLICAS=\"$$RANDOM\"; jq -n --arg replicas \"$$REPLICAS\" '{readyReplicas:$$replicas}'",
+  ]
 }
 
 resource "null_resource" "install_tiller" {

--- a/modules/helm-initializer/variables.tf
+++ b/modules/helm-initializer/variables.tf
@@ -20,3 +20,8 @@ variable "helm_dir_name" {
 variable "tiller_wait_period" {
   default = "40"
 }
+
+variable "tiller_connection_timeout" {
+  default     = "30"
+  description = "How long will Helm wait to establish a connection to tiller"
+}


### PR DESCRIPTION
This PR addresses issue when tiller is not redeployed after the cluster is re-created (for example by making an incompatible change, like disabling client cert auth, that forces TF to recreate the cluster).

Summary of changes:
- Remove create_before_destroy on `google_container_cluster`
- Add fix for redeploying tiller when cluster is recreated (introduce `tiller_status trigger`)
- Add and lower default `tiller_connection_timeout`

As part of that work `create_before_destroy` was removed, as this does not work anyway - GKE does not allow two clusters with the same name to exist at the same time and adds parametrized `tiller_connection_timeout` option to helm uninstall.

Unfortunately, this introduces slightly undesirable behavior that tiller is initially deployed twice, but I believe this is still preferred over tiller not being redeployed at all and therefore making everything else fail. And after thorough testing I didn't observe any side-effects of this happening.

As explained in the comment:
```
# This introduces undesired behavior that tiller will be deployed twice,
# as the trigger mechanism is not based on the state, but rather on the change
# of the state. So:
# - 1st run: resource does not exist, the trigger is evaluated to "" (empty)
#   -> resource is created
# - 2nd run: resource does exist, but the trigger changed to "1" -> resource
#   is recreated
# - 3rd and subsequent runs: resource does exist, trigger stays "1" -> no
#   changes unless the tiller is deleted or stops working, if that happens
#   the trigger changes and cycle described above will repeat once more
```