### PR TITLE
Parametrise force_update of helm_release

### DIFF
--- a/modules/helm-release/main.tf
+++ b/modules/helm-release/main.tf
@@ -54,7 +54,7 @@ resource "helm_release" "release" {
     "${var.extra_values == "" ? "" : file(coalesce(var.extra_values,"/dev/null"))}",
   ]
 
-  force_update     = false
+  force_update     = "${var.force_update}"
   devel            = true
   disable_webhooks = false
   timeout          = 500

--- a/modules/helm-release/variables.tf
+++ b/modules/helm-release/variables.tf
@@ -84,3 +84,8 @@ variable "ingress_basic_auth" {
     password    = ""
   }
 }
+
+variable "force_update" {
+  description = "Force resource update through delete/recreate if needed"
+  default     = false
+}


### PR DESCRIPTION
Exposes `force_update` parameter of `helm_release`, this is useful when resources can't be updated.

It's helm's `--force upgrade` functionality which :
> --force force resource update through delete/recreate if needed
--
(see https://docs.helm.sh/helm/helm_upgrade/ for details)