### PR TITLE
Gcp stackdriver export

### DIFF
--- a/modules/gcp-secret-mgmt/outputs.tf
+++ b/modules/gcp-secret-mgmt/outputs.tf
@@ -3,7 +3,7 @@ output "storage_buckets" {
 }
 
 output "encryption_keys" {
-  value = ["${google_kms_crypto_key.encryption_keys.*.id}"]
+  value = "${zipmap(var.encryption_keys, google_kms_crypto_key.encryption_keys.*.id)}"
 }
 
 output "keyring_id" {

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -17,7 +17,24 @@ provider "google" {
 # ------------------------------------------------------------------------------
 
 resource "google_storage_bucket" "exported-logs" {
-  name = "${var.project_id}-exported-logs"
+  name          = "${var.project_id}-exported-logs"
+  force_destroy = true
+  storage_class = "REGIONAL"
+  location      = "us-central1"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age = "${365 * 2}"
+    }
+  }
 }
 
 resource "google_logging_project_sink" "my-export" {

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -19,7 +19,7 @@ provider "google" {
 resource "google_storage_bucket" "exported-logs" {
   count         = "${var.exported_logs_encryption_key == "" ? 1 : 0}"
   name          = "${var.project_id}-exported-logs"
-  force_destroy = true
+  force_destroy = "${var.exported_logs_force_destroy}"
   storage_class = "${var.exported_logs_storage_class}"
   location      = "${var.exported_logs_storage_region}"
 
@@ -41,7 +41,7 @@ resource "google_storage_bucket" "exported-logs" {
 resource "google_storage_bucket" "exported-logs-custom-encryption" {
   count         = "${var.exported_logs_encryption_key == "" ? 0 : 1}"
   name          = "${var.project_id}-exported-logs"
-  force_destroy = true
+  force_destroy = "${var.exported_logs_force_destroy}"
   storage_class = "${var.exported_logs_storage_class}"
   location      = "${var.exported_logs_storage_region}"
 
@@ -113,10 +113,34 @@ resource "google_logging_project_sink" "my-export-custom-encryption" {
 
 # Because our sink uses a unique_writer, we must grant that writer access to
 # the bucket.
-resource "google_project_iam_binding" "exported-logs-writer" {
-  role = "roles/storage.objectCreator"
+resource "google_storage_bucket_iam_binding" "exported-logs-writer" {
+  count  = "${var.exported_logs_encryption_key == "" ? 1 : 0}"
+  bucket = "${google_storage_bucket.exported-logs.name}"
+  role   = "roles/storage.objectCreator"
 
   members = [
     "${google_logging_project_sink.my-export.*.writer_identity}",
   ]
+}
+
+resource "google_storage_bucket_iam_binding" "exported-logs-writer-custom-encryption" {
+  count  = "${var.exported_logs_encryption_key == "" ? 0 : 1}"
+  bucket = "${google_storage_bucket.exported-logs-custom-encryption.name}"
+  role   = "roles/storage.objectCreator"
+
+  members = [
+    "${google_logging_project_sink.my-export-custom-encryption.*.writer_identity}",
+  ]
+}
+
+# When writing to a bucket with custom encryption, we must also allow the GCS
+# Service Account to access the associated Cloud KMS Key.
+data "google_storage_project_service_account" "gcs_account" {}
+
+resource "google_kms_crypto_key_iam_binding" "exported-logs-writer-custom-encryption" {
+  count         = "${var.exported_logs_encryption_key == "" ? 0 : 1}"
+  crypto_key_id = "${var.exported_logs_encryption_key}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members       = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -49,6 +49,6 @@ resource "google_project_iam_binding" "exported-logs-writer" {
   role = "roles/storage.objectCreator"
 
   members = [
-    "${google_logging_project_sink.my-export.writer_identity}",
+    "${google_logging_project_sink.my-export.*.writer_identity}",
   ]
 }

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -19,8 +19,8 @@ provider "google" {
 resource "google_storage_bucket" "exported-logs" {
   name          = "${var.project_id}-exported-logs"
   force_destroy = true
-  storage_class = "REGIONAL"
-  location      = "us-central1"
+  storage_class = "${var.exported_logs_storage_class}"
+  location      = "${var.exported_logs_storage_region}"
 
   versioning {
     enabled = true
@@ -32,7 +32,7 @@ resource "google_storage_bucket" "exported-logs" {
     }
 
     condition {
-      age = "${365 * 2}"
+      age = "${var.exported_logs_expire_after}"
     }
   }
 }

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -142,5 +142,5 @@ resource "google_kms_crypto_key_iam_binding" "exported-logs-writer-custom-encryp
   crypto_key_id = "${var.exported_logs_encryption_key}"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members       = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+  members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -1,0 +1,54 @@
+# ------------------------------------------------------------------------------
+# TERRAFORM / PROVIDER CONFIG
+# ------------------------------------------------------------------------------
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "gcs" {}
+}
+
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
+# ------------------------------------------------------------------------------
+# GOOGLE STACKDRIVER EXPORT
+# ------------------------------------------------------------------------------
+
+resource "google_storage_bucket" "exported-logs" {
+  name = "${var.project_id}-exported-logs"
+}
+
+resource "google_logging_project_sink" "my-export" {
+  count       = "${length(var.exports)}"
+  name        = "${element(keys(var.exports), count.index)}"
+  destination = "storage.googleapis.com/${google_storage_bucket.exported-logs.name}"
+
+  # logName is a common thing to filter on. Per
+  # https://cloud.google.com/logging/docs/view/advanced-filters#minimize_global_and_substring_searches,
+  # it is best to match on an exact string. Doing so requires knowing
+  # var.project_id (since logName starts with "projects/my-project-id/").
+  # Neither Terraform variables (var.project_id) nor their environment variable
+  # cousins (TF_VAR_project_id) are availble from terraform.tfvars, where an
+  # instance of this module declares its filters. Hence, this workaround to
+  # replace the string "__var.project_id__" with the value of ${var.project_id}
+  # at runtime.
+  filter = "${replace(
+              element(values(var.exports), count.index),
+              "__var.project_id__",
+              "${var.project_id}"
+            )}"
+
+  unique_writer_identity = true
+}
+
+# Because our sink uses a unique_writer, we must grant that writer access to
+# the bucket.
+resource "google_project_iam_binding" "exported-logs-writer" {
+  role = "roles/storage.objectCreator"
+
+  members = [
+    "${google_logging_project_sink.my-export.writer_identity}",
+  ]
+}

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -35,6 +35,10 @@ resource "google_storage_bucket" "exported-logs" {
       age = "${var.exported_logs_expire_after}"
     }
   }
+
+  encryption {
+    default_kms_key_name = "${var.exported_logs_encryption_key}"
+  }
 }
 
 resource "google_logging_project_sink" "my-export" {

--- a/modules/gcp-stackdriver-export/main.tf
+++ b/modules/gcp-stackdriver-export/main.tf
@@ -17,6 +17,29 @@ provider "google" {
 # ------------------------------------------------------------------------------
 
 resource "google_storage_bucket" "exported-logs" {
+  count         = "${var.exported_logs_encryption_key == "" ? 1 : 0}"
+  name          = "${var.project_id}-exported-logs"
+  force_destroy = true
+  storage_class = "${var.exported_logs_storage_class}"
+  location      = "${var.exported_logs_storage_region}"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age = "${var.exported_logs_expire_after}"
+    }
+  }
+}
+
+resource "google_storage_bucket" "exported-logs-custom-encryption" {
+  count         = "${var.exported_logs_encryption_key == "" ? 0 : 1}"
   name          = "${var.project_id}-exported-logs"
   force_destroy = true
   storage_class = "${var.exported_logs_storage_class}"
@@ -42,9 +65,33 @@ resource "google_storage_bucket" "exported-logs" {
 }
 
 resource "google_logging_project_sink" "my-export" {
-  count       = "${length(var.exports)}"
+  count       = "${var.exported_logs_encryption_key == "" ? length(var.exports) : 0}"
+  count       = "${}"
   name        = "${element(keys(var.exports), count.index)}"
   destination = "storage.googleapis.com/${google_storage_bucket.exported-logs.name}"
+
+  # logName is a common thing to filter on. Per
+  # https://cloud.google.com/logging/docs/view/advanced-filters#minimize_global_and_substring_searches,
+  # it is best to match on an exact string. Doing so requires knowing
+  # var.project_id (since logName starts with "projects/my-project-id/").
+  # Neither Terraform variables (var.project_id) nor their environment variable
+  # cousins (TF_VAR_project_id) are availble from terraform.tfvars, where an
+  # instance of this module declares its filters. Hence, this workaround to
+  # replace the string "__var.project_id__" with the value of ${var.project_id}
+  # at runtime.
+  filter = "${replace(
+              element(values(var.exports), count.index),
+              "__var.project_id__",
+              "${var.project_id}"
+            )}"
+
+  unique_writer_identity = true
+}
+
+resource "google_logging_project_sink" "my-export-custom-encryption" {
+  count       = "${var.exported_logs_encryption_key == "" ? 0 : length(var.exports)}"
+  name        = "${element(keys(var.exports), count.index)}"
+  destination = "storage.googleapis.com/${google_storage_bucket.exported-logs-custom-encryption.name}"
 
   # logName is a common thing to filter on. Per
   # https://cloud.google.com/logging/docs/view/advanced-filters#minimize_global_and_substring_searches,

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -1,7 +1,6 @@
 # ------------------------------------------------------------------------------
 # REQUIRED VARIABLES
 # ------------------------------------------------------------------------------
-
 variable "project_id" {
   description = "Project where resources will be created"
 }
@@ -32,4 +31,9 @@ variable "exported_logs_storage_region" {
 
 variable "exported_logs_expire_after" {
   default = "14"
+}
+
+variable "exported_logs_encryption_key" {
+  description = "Name of a KMS key to use (e.g. projects/my-project/locations/global/keyRings/keyring/cryptoKeys/gcp-stackdriver-export). Empty string means use Google's default encryption."
+  default     = ""
 }

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -16,7 +16,7 @@ variable "serviceaccount_key" {
 
 variable "exports" {
   type        = "map"
-  description = "Map of Stackdriver export rules where keys are names of rules and values are filters implementing those rules"
+  description = "Map of Stackdriver export rules where keys are names of rules and values are filters implementing those rules. (__var.project_id__ is replaced with $var.project_id at runtime -- useful for matching logName exactly for efficient filtering.)"
 
   # Example: {"exclude-all-foo" = "logName=\"projects/__var.project_id__/logs/foo\"}
   default = {}

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------------------
+# REQUIRED VARIABLES
+# ------------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "Project where resources will be created"
+}
+
+variable "serviceaccount_key" {
+  description = "Service account key for the project"
+}
+
+# ------------------------------------------------------------------------------
+# OPTIONAL VARIABLES
+# ------------------------------------------------------------------------------
+
+variable "exports" {
+  type        = "map"
+  description = "Map of Stackdriver export rules where keys are names of rules and values are filters implementing those rules"
+
+  # Example: {"exclude-all-foo" = "logName=\"projects/__var.project_id__/logs/foo\"}
+  default = {}
+}

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -21,16 +21,24 @@ variable "exports" {
   default = {}
 }
 
+variable "exported_logs_force_destroy" {
+  description = "If 'true', the exported logs bucket will be destroyed on 'terragrunt destroy' or (NOTE!) on certain kinds of reconfiguration, e.g. changing storage class from REGIONAL to NEARLINE. Use caution when setting to 'true'."
+  default     = "false"
+}
+
 variable "exported_logs_storage_class" {
-  default = "REGIONAL"
+  description = "Storage class for bucket containing exported logs."
+  default     = "REGIONAL"
 }
 
 variable "exported_logs_storage_region" {
-  default = "europe-north1-a"
+  description = "Region for bucket containing exported logs."
+  default     = "europe-north1-a"
 }
 
 variable "exported_logs_expire_after" {
-  default = "14"
+  description = "Exported logs are deleted from the bucket after this many days."
+  default     = "14"
 }
 
 variable "exported_logs_encryption_key" {

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -18,7 +18,7 @@ variable "exports" {
   type        = "map"
   description = "Map of Stackdriver export rules where keys are names of rules and values are filters implementing those rules. (__var.project_id__ is replaced with $var.project_id at runtime -- useful for matching logName exactly for efficient filtering.)"
 
-  # Example: {"exclude-all-foo" = "logName=\"projects/__var.project_id__/logs/foo\"}
+  # Example: {"export-all-foo" = "logName=\"projects/__var.project_id__/logs/foo\"}
   default = {}
 }
 

--- a/modules/gcp-stackdriver-export/variables.tf
+++ b/modules/gcp-stackdriver-export/variables.tf
@@ -21,3 +21,15 @@ variable "exports" {
   # Example: {"exclude-all-foo" = "logName=\"projects/__var.project_id__/logs/foo\"}
   default = {}
 }
+
+variable "exported_logs_storage_class" {
+  default = "REGIONAL"
+}
+
+variable "exported_logs_storage_region" {
+  default = "europe-north1-a"
+}
+
+variable "exported_logs_expire_after" {
+  default = "14"
+}


### PR DESCRIPTION
Similar to https://github.com/exekube/exekube/pull/104.

See https://issues.gpii.net/browse/GPII-3324 for the motivation for this module.

See https://github.com/gpii-ops/gpii-infra/blob/master/gcp/modules/gcp-stackdriver-export/main.tf for an example of how we use this module in gpii-infra.

We had a lot of discussion about how to handle injection of project_id into filters for exact matching: gpii-ops#12 (comment). (There is also discussion in this PR, though it's a little more chaotic: gpii-ops/gpii-infra#114)

