### PR TITLE
Add support for regional GKE clusters

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -7,7 +7,15 @@ terraform {
   backend "gcs" {}
 }
 
+# Keep non-beta provider to be backward compatible
 provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
+# Beta features will be available only in beta provider from 2.0
+# https://www.terraform.io/docs/providers/google/provider_versions.html
+provider "google-beta" {
   project     = "${var.project_id}"
   credentials = "${var.serviceaccount_key}"
 }
@@ -19,6 +27,7 @@ provider "google" {
 resource "google_container_cluster" "cluster" {
   name = "${var.cluster_name}"
   zone = "${var.main_compute_zone}"
+  provider = "google-beta"
 
   additional_zones = "${var.additional_zones}"
 

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -25,8 +25,10 @@ provider "google-beta" {
 # ------------------------------------------------------------------------------
 
 # Check that only one of region and main_compute_zone is set
+# This is to get a reasonable error message out of Terraform, however weird it
+# might look like
 resource "null_resource" "region_or_zone" {
-  count                                                         = "${var.region == "" || var.main_compute_zone == "" ? 0 : 1}"
+  count                                                         = "${var.region != "" && var.main_compute_zone != "" ? 1 : 0}"
   "ERROR: Only one of region and main_compute_zone may be set." = true
 }
 

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -24,10 +24,17 @@ provider "google-beta" {
 # GOOGLE KUBERNTES ENGINE CLUSTER
 # ------------------------------------------------------------------------------
 
+# Check that only one of region and main_compute_zone is set
+resource "null_resource" "region_or_zone" {
+  count                                                         = "${var.region == "" || var.main_compute_zone == "" ? 0 : 1}"
+  "ERROR: Only one of region and main_compute_zone may be set." = true
+}
+
 resource "google_container_cluster" "cluster" {
-  name = "${var.cluster_name}"
-  zone = "${var.main_compute_zone}"
   provider = "google-beta"
+  count    = "${var.region == "" ? 1 : 0}"
+  name     = "${var.cluster_name}"
+  zone     = "${var.main_compute_zone}"
 
   additional_zones = "${var.additional_zones}"
 
@@ -105,5 +112,101 @@ creator-cluster-admin-binding \
 --user=$(gcloud info --format='value(config.account)') \
 && helm init --client-only
 EOF
+  }
+}
+
+resource "google_container_cluster" "cluster-regional" {
+  provider = "google-beta"
+  count    = "${var.region == "" ? 0 : 1}"
+  name     = "${var.cluster_name}"
+  region   = "${var.region}"
+
+  additional_zones = "${var.additional_zones}"
+
+  initial_node_count      = "${var.initial_node_count}"
+  node_version            = "${var.kubernetes_version}"
+  min_master_version      = "${var.kubernetes_version}"
+  enable_kubernetes_alpha = "${var.enable_kubernetes_alpha}"
+  enable_legacy_abac      = "false"
+  network                 = "${var.network_name}"
+  subnetwork              = "nodes"
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
+
+  addons_config {
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+
+    kubernetes_dashboard {
+      disabled = "${var.dashboard_disabled}"
+    }
+
+    http_load_balancing {
+      disabled = false
+    }
+
+    network_policy_config {
+      disabled = false
+    }
+  }
+
+  monitoring_service = "${var.monitoring_service}"
+  logging_service    = "${var.logging_service}"
+
+  maintenance_policy {
+    daily_maintenance_window {
+      start_time = "03:00"
+    }
+  }
+
+  node_config {
+    machine_type = "${var.node_type}"
+    disk_size_gb = 200
+    oauth_scopes = "${var.oauth_scopes}"
+    image_type   = "${var.node_image_type}"
+
+    labels {
+      project = "${var.project_id}"
+      pool    = "default"
+    }
+  }
+
+  network_policy {
+    enabled  = true
+    provider = "CALICO"
+  }
+
+  master_auth {
+    username = "${var.master_auth_username}"
+    password = "${var.master_auth_password}"
+
+    client_certificate_config {
+      issue_client_certificate = "${var.issue_client_certificate}"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+gcloud auth activate-service-account --key-file ${var.serviceaccount_key} \
+&& gcloud container clusters get-credentials ${var.cluster_name} \
+--region ${var.region} \
+--project ${var.project_id} \
+&& kubectl label ns kube-system name=kube-system \
+&& kubectl create clusterrolebinding \
+creator-cluster-admin-binding \
+--clusterrole=cluster-admin \
+--user=$(gcloud info --format='value(config.account)') \
+&& helm init --client-only
+EOF
+  }
+
+  timeouts {
+    create = "${var.create_timeout}"
+    update = "${var.update_timeout}"
+    delete = "${var.delete_timeout}"
   }
 }

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -23,7 +23,13 @@ variable "network_name" {
 }
 
 variable "main_compute_zone" {
-  default = "europe-north1-a"
+  description = "Master zone (only one of region and main_compute_zone may be set)"
+  default     = ""
+}
+
+variable "region" {
+  description = "Cluster region (only one of region and main_compute_zone may be set)"
+  default     = ""
 }
 
 variable "additional_zones" {


### PR DESCRIPTION
This PR:
- Updates provider to `google-beta` one, see https://www.terraform.io/docs/providers/google/provider_versions.html for details

- Add support for regional cluster by adding `region` argument. Only one of `region` and `main_computer_zone` my be set.

This is non-breaking change, if you use and want to keep using zonal cluster, no changes are needed.

Migration - If you already have existing zonal cluster and want to move to regional, you should:
- Set `region` argument
- Unset `main_compute_zone` one
- Move object in Terrafrom state to a new name, such as `terraform state mv google_container_cluster.cluster
google_container_cluster.cluster-regional` before running `terraform apply`. This will still re-create a
cluster, but it should work without manual intervention.

**_This is destructive operation and will still re-create the cluster, as change from zonal to regional cluster type requires so_**