### PR TITLE
Upgrade/downgrade gke and kubectl version to 1.12.7

### DIFF
--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -53,7 +53,7 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
         && gcloud config set component_manager/disable_update_check true \
         && rm -rf /google-cloud-sdk/.install/.backup
 
-ENV KUBECTL_VERSION 1.13.4
+ENV KUBECTL_VERSION 1.12.7
 RUN curl -L -o kubectl \
         https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
         && chmod 0700 kubectl \

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -64,7 +64,7 @@ variable "initial_node_count" {
 }
 
 variable "kubernetes_version" {
-  default = "1.10.5-gke.0"
+  default = "1.12.7-gke.7"
 }
 
 variable "monitoring_service" {
@@ -89,7 +89,7 @@ variable "issue_client_certificate" {
   default     = true
   description = "Whether client certificate authorization is enabled"
 }
-  
+
 variable "create_timeout" {
   default = "30m"
 }
@@ -103,6 +103,6 @@ variable "delete_timeout" {
 }
 
 variable "dashboard_disabled" {
-  default = false
+  default     = false
   description = "Disable Kubernetes Dashboard"
 }


### PR DESCRIPTION
- Upgrade in `gke-cluster` module
- Downgrade prematurely upgraded (to `1.13`) in exekube/exekube:0.5.0-google` Docker image