### PR TITLE
Add helmfile module as an alternative to helm-release and helm-template-release

### DIFF
--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -89,6 +89,12 @@ RUN curl -L -o ./tph.tar.gz \
         && mkdir -p /root/.terraform.d/plugins/ \
         && mv terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} /root/.terraform.d/plugins/
 
+ENV HELMFILE_VERSION 0.54.2
+RUN curl -L -o helmfile \
+        https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_linux_amd64 \
+        && chmod 0700 helmfile \
+        && mv helmfile /usr/bin
+
 COPY terraform-plugins /terraform-plugins/
 
 RUN cd /terraform-plugins \

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -67,7 +67,7 @@ RUN curl -L -o helm.tar.gz \
         && chmod 0700 linux-amd64/helm \
         && mv linux-amd64/helm /usr/bin
 
-ENV TERRAFORM_VERSION 0.11.8
+ENV TERRAFORM_VERSION 0.11.12
 RUN curl -o ./terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
         && unzip terraform.zip \
         && mv terraform /usr/bin \

--- a/modules/helmfile/main.tf
+++ b/modules/helmfile/main.tf
@@ -2,7 +2,7 @@ provider "local" {}
 
 resource "null_resource" "helmfile_sync" {
   triggers {
-    release_timestamp = "${timestamp()}"
+    helmfile_checksum = "${filesha512("${path.root}/${var.helmfile_path}")}"
   }
 
   provisioner "local-exec" {

--- a/modules/helmfile/main.tf
+++ b/modules/helmfile/main.tf
@@ -1,0 +1,30 @@
+provider "local" {}
+
+resource "null_resource" "helmfile_sync" {
+  triggers {
+    release_timestamp = "${timestamp()}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+helmfile --quiet --file ${path.root}/${var.helmfile_path} \
+  --environment ${var.helmfile_environment} \
+  sync
+EOF
+  }
+}
+
+resource "null_resource" "helmfile_destroy" {
+  count = "${var.prevent_destroy ? 0 : 1}"
+
+  provisioner "local-exec" {
+    when       = "destroy"
+    on_failure = "continue"
+
+    command = <<EOF
+helmfile --quiet --file ${path.root}/${var.helmfile_path} \
+  --environment ${var.helmfile_environment} \
+  destroy
+EOF
+  }
+}

--- a/modules/helmfile/variables.tf
+++ b/modules/helmfile/variables.tf
@@ -1,0 +1,11 @@
+variable "helmfile_path" {
+  default = "helmfile.yaml"
+}
+
+variable "helmfile_environment" {
+  default = "default"
+}
+
+variable "prevent_destroy" {
+  default = false
+}


### PR DESCRIPTION
- Add `helmfile` binary to Docker image
- Add `helmfile` module that can be used as a more flexible alternative to `helm-release` or `helm-template-release` modules