### PR TITLE
Plumbing for Binary Auth in GKE

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: exekube/exekube:0.5.0-google
+    image: exekube/exekube:0.5.1-google
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -98,7 +98,6 @@ resource "google_container_cluster" "cluster" {
     provider = "CALICO"
   }
 
-
   provisioner "local-exec" {
     command = <<EOF
 gcloud auth activate-service-account --key-file ${var.serviceaccount_key} \
@@ -129,10 +128,10 @@ resource "google_container_cluster" "cluster-regional" {
 
   additional_zones = "${var.additional_zones}"
 
-  initial_node_count      = "${var.initial_node_count}"
-  node_version            = "${var.kubernetes_version}"
-  min_master_version      = "${var.kubernetes_version}"
-  enable_kubernetes_alpha = "${var.enable_kubernetes_alpha}"
+  initial_node_count          = "${var.initial_node_count}"
+  node_version                = "${var.kubernetes_version}"
+  min_master_version          = "${var.kubernetes_version}"
+  enable_kubernetes_alpha     = "${var.enable_kubernetes_alpha}"
   enable_binary_authorization = "${var.enable_binary_authorization}"
   enable_legacy_abac          = false
   network                     = "${var.network_name}"

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -40,13 +40,14 @@ resource "google_container_cluster" "cluster" {
 
   additional_zones = "${var.additional_zones}"
 
-  initial_node_count      = "${var.initial_node_count}"
-  node_version            = "${var.kubernetes_version}"
-  min_master_version      = "${var.kubernetes_version}"
-  enable_kubernetes_alpha = "${var.enable_kubernetes_alpha}"
-  enable_legacy_abac      = "false"
-  network                 = "${var.network_name}"
-  subnetwork              = "nodes"
+  initial_node_count          = "${var.initial_node_count}"
+  node_version                = "${var.kubernetes_version}"
+  min_master_version          = "${var.kubernetes_version}"
+  enable_kubernetes_alpha     = "${var.enable_kubernetes_alpha}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
+  enable_legacy_abac          = "false"
+  network                     = "${var.network_name}"
+  subnetwork                  = "nodes"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "pods"
@@ -132,6 +133,7 @@ resource "google_container_cluster" "cluster-regional" {
   node_version            = "${var.kubernetes_version}"
   min_master_version      = "${var.kubernetes_version}"
   enable_kubernetes_alpha = "${var.enable_kubernetes_alpha}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
   enable_legacy_abac      = "false"
   network                 = "${var.network_name}"
   subnetwork              = "nodes"

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -45,7 +45,7 @@ resource "google_container_cluster" "cluster" {
   min_master_version          = "${var.kubernetes_version}"
   enable_kubernetes_alpha     = "${var.enable_kubernetes_alpha}"
   enable_binary_authorization = "${var.enable_binary_authorization}"
-  enable_legacy_abac          = "false"
+  enable_legacy_abac          = false
   network                     = "${var.network_name}"
   subnetwork                  = "nodes"
 
@@ -134,9 +134,9 @@ resource "google_container_cluster" "cluster-regional" {
   min_master_version      = "${var.kubernetes_version}"
   enable_kubernetes_alpha = "${var.enable_kubernetes_alpha}"
   enable_binary_authorization = "${var.enable_binary_authorization}"
-  enable_legacy_abac      = "false"
-  network                 = "${var.network_name}"
-  subnetwork              = "nodes"
+  enable_legacy_abac          = false
+  network                     = "${var.network_name}"
+  subnetwork                  = "nodes"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "pods"

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -37,7 +37,11 @@ variable "additional_zones" {
 }
 
 variable "enable_kubernetes_alpha" {
-  default = "false"
+  default = false
+}
+
+variable "enable_binary_authorization" {
+  default = false
 }
 
 variable "oauth_scopes" {


### PR DESCRIPTION
This adds plumbing to enable binary authorization in GKE clusters.

BTW Ilya we're planning to get a little more serious about versioning, so I've included a version bump with this change. Let me know if you don't want that, and we'll worry about versioning exclusively on our end (we'll be doing our own tagging/versioning anyway so it's not a problem).