### PR TITLE
Upgrade Terraform, providers and other various components

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: exekube/exekube:0.5.1-google
+    image: exekube/exekube:0.6.0-google
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -38,7 +38,7 @@ RUN apk --no-cache add \
         jq \
         gnupg
 
-ENV CLOUD_SDK_VERSION 242.0.0
+ENV CLOUD_SDK_VERSION 247.0.0
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
         && tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz \
@@ -53,13 +53,13 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
         && gcloud config set component_manager/disable_update_check true \
         && rm -rf /google-cloud-sdk/.install/.backup
 
-ENV KUBECTL_VERSION 1.12.7
+ENV KUBECTL_VERSION 1.12.8
 RUN curl -L -o kubectl \
         https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
         && chmod 0700 kubectl \
         && mv kubectl /usr/bin
 
-ENV HELM_VERSION 2.13.1
+ENV HELM_VERSION 2.14.0
 RUN curl -L -o helm.tar.gz \
         https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
         && tar -xvzf helm.tar.gz \
@@ -67,27 +67,17 @@ RUN curl -L -o helm.tar.gz \
         && chmod 0700 linux-amd64/helm \
         && mv linux-amd64/helm /usr/bin
 
-ENV TERRAFORM_VERSION 0.11.12
+ENV TERRAFORM_VERSION 0.11.14
 RUN curl -o ./terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
         && unzip terraform.zip \
         && mv terraform /usr/bin \
         && rm -rf terraform.zip
 
-ENV TERRAGRUNT_VERSION 0.18.3
+ENV TERRAGRUNT_VERSION 0.18.6
 RUN curl -L -o ./terragrunt \
         https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 \
         && chmod 0700 terragrunt \
         && mv terragrunt /usr/bin
-
-ENV TERRAFORM_PROVIDER_HELM_VERSION 0.7.0
-RUN curl -L -o ./tph.tar.gz \
-        https://github.com/gpii-ops/terraform-provider-helm/releases/download/v${TERRAFORM_PROVIDER_HELM_VERSION}/terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION}_linux_amd64.tar.gz \
-        && tar -xvzf tph.tar.gz \
-        && rm -rf tph.tar.gz \
-        && cd terraform-provider-helm_linux_amd64 \
-        && chmod 0700 terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} \
-        && mkdir -p /root/.terraform.d/plugins/ \
-        && mv terraform-provider-helm_v${TERRAFORM_PROVIDER_HELM_VERSION} /root/.terraform.d/plugins/
 
 ENV HELMFILE_VERSION 0.54.2
 RUN curl -L -o helmfile \
@@ -100,6 +90,7 @@ COPY terraform-plugins /terraform-plugins/
 RUN cd /terraform-plugins \
     && terraform init \
     && find /terraform-plugins \
+    && mkdir -p /root/.terraform.d/plugins \
     && cp /terraform-plugins/.terraform/plugins/linux_amd64/terraform-provider* /root/.terraform.d/plugins/ \
     && cd \
     && rm -fr /terraform-plugins

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -59,7 +59,7 @@ RUN curl -L -o kubectl \
         && chmod 0700 kubectl \
         && mv kubectl /usr/bin
 
-ENV HELM_VERSION 2.14.0
+ENV HELM_VERSION 2.13.1
 RUN curl -L -o helm.tar.gz \
         https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
         && tar -xvzf helm.tar.gz \

--- a/terraform-plugins/providers.tf
+++ b/terraform-plugins/providers.tf
@@ -1,37 +1,45 @@
 # This is the list of Terraform plugins to be installed in the exekube container
 
 provider "google" {
-  version = "~> 1.16"
+  version = "~> 2.7.0"
+}
+
+provider "google-beta" {
+  version = "~> 2.7.0"
 }
 
 provider "random" {
-  version = "~> 1.3"
+  version = "~> 2.1.2"
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "kubernetes" {
-  version = "~> 1.1"
+  version = "~> 1.6.2"
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {
-  version = "~> 1.2"
+  version = "~> 2.0.1"
 }
 
 provider "local" {
-  version = "~> 1.1"
+  version = "~> 1.2.2"
 }
 
 provider "external" {
-  version = "~> 1.0"
+  version = "~> 1.1.2"
 }
 
 provider "aws" {
-  version = "~> 1.36"
+  version = "~> 2.11.0"
+}
+
+provider "helm" {
+  version = "~> 0.9.1"
 }


### PR DESCRIPTION
This PR:
- updates Terraform
- updates Google Cloud SDK
- updates kubectl
- ~updates Helm~
- updates Terragrunt
- updates all Terraform providers to the latest
- moves to vanilla Helm provider, as the changes have been merged upstream

This mainly fixes node_pool recreation due to metadata config - see https://github.com/GoogleCloudPlatform/magic-modules/pull/1507 for details.

Note: Helm update was reverted due to an issue with spec validation (see https://github.com/helm/helm/issues/5750). This should be fixed in soon to be 0.14.1, but it was not available at the time of this PR yet.