### PR TITLE
Add istioctl to google image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: exekube/exekube:0.5.1-google
+    image: exekube/exekube:0.7.0-google
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/dockerfiles/google/Dockerfile
+++ b/dockerfiles/google/Dockerfile
@@ -95,6 +95,14 @@ RUN curl -L -o helmfile \
         && chmod 0700 helmfile \
         && mv helmfile /usr/bin
 
+ENV ISTIOCTL_VERSION 1.0.6
+RUN curl -L -o istio.tar.gz \
+        https://github.com/istio/istio/releases/download/${ISTIOCTL_VERSION}/istio-${ISTIOCTL_VERSION}-linux.tar.gz \
+        && tar -xzvf istio.tar.gz \
+        && chmod 0700 istio-${ISTIOCTL_VERSION}/bin/istioctl \
+        && mv istio-${ISTIOCTL_VERSION}/bin/istioctl /usr/bin \
+        && rm -rf istio.tar.gz istio-${ISTIOCTL_VERSION}
+
 COPY terraform-plugins /terraform-plugins/
 
 RUN cd /terraform-plugins \


### PR DESCRIPTION
`istioctl` binary is needed to manage Istio resources using istio-enabled GKE clusters.
This needs to be merged after #124 to keep proper image versioning.