### PR TITLE
Add support for disabling GKE L7 load balancer

### DIFF
--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -64,7 +64,7 @@ resource "google_container_cluster" "cluster" {
     }
 
     http_load_balancing {
-      disabled = false
+      disabled = "${var.http_load_balancing_disabled}"
     }
 
     network_policy_config {

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -110,3 +110,8 @@ variable "dashboard_disabled" {
   default     = false
   description = "Disable Kubernetes Dashboard"
 }
+
+variable "http_load_balancing_disabled" {
+  default     = false
+  description = "Disable GKE HTTP (L7) load balancing controller addon"
+}


### PR DESCRIPTION
This PR adds support for disabling GKE HTTP (L7) load balancing controller addon.