### PR TITLE
Fix gke-network module output when create_static_ip_address is disabled

### DIFF
--- a/modules/gke-network/outputs.tf
+++ b/modules/gke-network/outputs.tf
@@ -1,6 +1,6 @@
 /*
 output "static_ip_address" {
-  value = "${google_compute_address.ingress_controller_ip.0.address}"
+  value = "${element(concat(google_compute_address.ingress_controller_ip.*.address, list("")), 0)}"
 }
 */
 


### PR DESCRIPTION
This PR fixes the output of `gke-network` module when `create_static_ip_address` is set to `false`.

Current error:
```yaml
Error: Error applying plan:

1 error occurred:
        * module.gke_network.output.static_ip_address: Resource 'google_compute_address.ingress_controller_ip.0' does not have attribute 'address' for variable 'google_compute_address.ingress_controller_ip.0.address'
```