### PR TITLE
Remove helm init from gke-cluster

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   # Build Exekube images and tag them
   # Usage: `docker-compose build <service-name>`
   google:
-    image: exekube/exekube:0.8.0-google
+    image: exekube/exekube:0.8.1-google
     build:
       context: .
       dockerfile: dockerfiles/google/Dockerfile

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -108,8 +108,7 @@ gcloud auth activate-service-account --key-file ${var.serviceaccount_key} \
 && kubectl create clusterrolebinding \
 creator-cluster-admin-binding \
 --clusterrole=cluster-admin \
---user=$(gcloud info --format='value(config.account)') \
-&& helm init --client-only
+--user=$(gcloud info --format='value(config.account)')
 EOF
   }
 
@@ -214,8 +213,7 @@ gcloud auth activate-service-account --key-file ${var.serviceaccount_key} \
 && kubectl create clusterrolebinding \
 creator-cluster-admin-binding \
 --clusterrole=cluster-admin \
---user=$(gcloud info --format='value(config.account)') \
-&& helm init --client-only
+--user=$(gcloud info --format='value(config.account)')
 EOF
   }
 


### PR DESCRIPTION
There is no need to touch helm in `gke-cluster`, since there is a separate `helm-initializer` module, and this also breaks things when Helm env vars are set (https://github.com/gpii-ops/gpii-infra/pull/461).