### PR TITLE
Make tiller_status fail fast when it can't reach the cluster

### DIFF
--- a/modules/helm-initializer/main.tf
+++ b/modules/helm-initializer/main.tf
@@ -44,7 +44,7 @@ data "external" "tiller_status" {
   program = [
     "bash",
     "-c",
-    "REPLICAS=$$(kubectl get deploy tiller-deploy -n ${var.tiller_namespace} -o jsonpath='{.status.readyReplicas}'); [ \"$$REPLICAS\" != \"1\" ] && REPLICAS=\"$$RANDOM\"; jq -n --arg replicas \"$$REPLICAS\" '{readyReplicas:$$replicas}'",
+    "REPLICAS=$$(kubectl get deploy tiller-deploy --request-timeout 5s -n ${var.tiller_namespace} -o jsonpath='{.status.readyReplicas}'); [ \"$$REPLICAS\" != \"1\" ] && REPLICAS=\"$$RANDOM\"; jq -n --arg replicas \"$$REPLICAS\" '{readyReplicas:$$replicas}'",
   ]
 }
 


### PR DESCRIPTION
This makes `tiller_status` fail faster (by 2m) when it can't reach a cluster (like running `rake destroy` on a non-existing cluster).

```
bash-4.4# time kubectl get deploy tiller-deploy
Unable to connect to the server: dial tcp 35.226.36.16:443: i/o timeout

real    2m29.933s
user    0m0.090s
sys     0m0.030s

bash-4.4# time kubectl get deploy tiller-deploy --request-timeout 5s
E0731 12:16:33.261546     105 round_trippers.go:174] CancelRequest not implemented by *gcp.conditionalTransport
E0731 12:16:38.264127     105 round_trippers.go:174] CancelRequest not implemented by *gcp.conditionalTransport
E0731 12:16:48.269822     105 round_trippers.go:174] CancelRequest not implemented by *gcp.conditionalTransport
E0731 12:16:53.238107     105 round_trippers.go:174] CancelRequest not implemented by *gcp.conditionalTransport
Unable to connect to the server: context deadline exceeded

real    0m25.069s
user    0m0.060s
sys     0m0.050s
```